### PR TITLE
Update action to allow more felxibilty

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,5 +72,15 @@ with:
   working-directory: "frontend"
 ```
 
+### Process jest result and publish
+
+```yaml
+uses: mattallty/jest-github-action@v1
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+with:
+  process-only: true
+  results-file: "jest.results.json"
+```
 
 See the [actions tab](https://github.com/mattallty/jest-github-action/actions) for runs of this action! :rocket:

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,14 @@ branding:
   icon: "check"
   color: "blue"
 inputs:
+  process-only:
+    description: "Only process the result file"
+    required: false
+    default: "false"
+  results-file:
+    description: "Filename for the jest result file"
+    required: false
+    default: "jest.results.json"
   test-command:
     description: "The test command to run"
     required: false

--- a/src/action.ts
+++ b/src/action.ts
@@ -18,10 +18,7 @@ const COVERAGE_HEADER = ":loop: **Code coverage**\n\n"
 export async function run() {
   let workingDirectory = core.getInput("working-directory", { required: false })
   let cwd = workingDirectory ? resolve(workingDirectory) : process.cwd()
-  let resultFileName = core.getInput("results-file", { required: false })
-  if (resultFileName === "") {
-    resultFileName = "jest.results.json";
-  }
+  const resultFileName = core.getInput("results-file", { required: false }) || "jest.results.json"
   let processOnly = core.getInput("process-only", { required: false })
 
   const CWD = cwd + sep

--- a/src/action.ts
+++ b/src/action.ts
@@ -18,9 +18,15 @@ const COVERAGE_HEADER = ":loop: **Code coverage**\n\n"
 export async function run() {
   let workingDirectory = core.getInput("working-directory", { required: false })
   let cwd = workingDirectory ? resolve(workingDirectory) : process.cwd()
-  const CWD = cwd + sep
-  const RESULTS_FILE = join(CWD, "jest.results.json")
+  let resultFileName = core.getInput("results-file", { required: false })
+  if (resultFileName === "") {
+    resultFileName = "jest.results.json";
+  }
+  let processOnly = core.getInput("process-only", { required: false })
 
+  const CWD = cwd + sep
+  const RESULTS_FILE = join(CWD, resultFileName)
+  
   try {
     const token = process.env.GITHUB_TOKEN
     if (token === undefined) {
@@ -29,9 +35,14 @@ export async function run() {
       return
     }
 
-    const cmd = getJestCommand(RESULTS_FILE)
+    if (processOnly === "true") {
+      console.log("Processing file: " + RESULTS_FILE)
+    } else {
+      const cmd = getJestCommand(RESULTS_FILE)
 
-    await execJest(cmd, CWD)
+      await execJest(cmd, CWD)
+
+    }
 
     // octokit
     const octokit = new GitHub(token)


### PR DESCRIPTION
Add new parameter `results-file` to allow specifying jest result filename.
Add new parameter `process-only` to skip running jest and process existing results file.